### PR TITLE
Gracefully shut down the multiprocessing objects

### DIFF
--- a/cmd/export.py
+++ b/cmd/export.py
@@ -192,7 +192,7 @@ def logging_process(logging_queue):
         except queue.Empty:
             print("Queue is empty, killing logging process")
             break
-        except ValueError:
+        except (ValueError, EOFError):
             print("Queue is closed, killing logging process")
             break
         except Exception:

--- a/cmd/export.py
+++ b/cmd/export.py
@@ -189,9 +189,19 @@ def logging_process(queue):
                 queue.close()
                 break
             logger.info(record)
+        except queue.Empty:
+            print("Queue is empty, killing logging process")
+            queue.close()
+            break
+        except ValueError:
+            print("Queue is closed, killing logging process")
+            queue.close()
+            break
         except Exception:
-            print("Error logging record")
+            print("Queue is broken")
             traceback.print_exc()
+            queue.close()
+            break
 
 
 def main():

--- a/cmd/export.py
+++ b/cmd/export.py
@@ -401,7 +401,6 @@ def graceful_shutdown(listener, logging_queue, exit_code):
 
     # Put one last record on the logging_queue to kill it and then wait
     logging_queue.put_nowait(None)
-    logging_queue.join()
 
     # Now disable the listener
     listener.join()

--- a/s3access/normalize.py
+++ b/s3access/normalize.py
@@ -83,7 +83,7 @@ def transform_items(items):
     return [transform_item(item) for item in items]
 
 
-def deserialize_file(f, fs, queue):
+def deserialize_file(f, fs, logging_queue):
     items = transform_items(deserialize(src=f, format="csv", fs=fs))
-    queue.put("Completed deserializing {}".format(f))
+    logging_queue.put("Completed deserializing {}".format(f))
     return items

--- a/s3access/parquet.py
+++ b/s3access/parquet.py
@@ -10,8 +10,8 @@ from pyarrow.util import guid
 from s3access.wg import WaitGroup
 
 
-def write_partition(df, full_path, cols, schema, compression, fs, queue):
-    queue.put("write_partition: {}".format(full_path))
+def write_partition(df, full_path, cols, schema, compression, fs, logging_queue):
+    logging_queue.put("write_partition: {}".format(full_path))
     try:
         writer = pq.ParquetWriter(
             full_path, schema, compression=compression, filesystem=fs
@@ -22,7 +22,7 @@ def write_partition(df, full_path, cols, schema, compression, fs, queue):
 
         writer.close()
     except Exception as err:
-        queue.put("Unable to write partition {}: {}".format(full_path, err))
+        logging_queue.put("Unable to write partition {}: {}".format(full_path, err))
         traceback.print_exc()
 
 
@@ -40,7 +40,7 @@ def write_dataset(
     cpu_count=None,
     makedirs=False,
     timeout=None,
-    queue=None,
+    logging_queue=None,
 ):
 
     df = table.to_pandas()
@@ -103,7 +103,7 @@ def write_dataset(
                     subschema,
                     compression,
                     fs,
-                    queue,
+                    logging_queue,
                 ),
                 callback=write_partition_callback,
                 error_callback=write_partition_error_callback,


### PR DESCRIPTION
Add graceful shut down of multiprocessing objects. This should help the ECS tasks exit correctly.

## Details

I see this error in the ECS task logs:

```text
2021-04-23T15:10:29.975-07:00 | AttributeError: 'ForkAwareLocal' object has no attribute 'connection'
```

The larger context is:

<img width="998" alt="Screen Shot 2021-04-23 at 3 35 40 PM" src="https://user-images.githubusercontent.com/219296/115936278-a69ff200-a449-11eb-9e5c-643482a2ac1b.png">

The cause of this is likely that the multiprocessing `Process` and `Queue` are not being properly closed before exiting the main program. 
